### PR TITLE
Update kubectl to 1.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN cat /etc/ssl/certs/*.pem > /etc/ssl/certs/ca-certificates.crt
 ADD http://stedolan.github.io/jq/download/linux64/jq /usr/local/bin/jq
 RUN chmod +x /usr/local/bin/jq
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.2.2/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.3.4/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl
 
 ADD assets/ /opt/resource/


### PR DESCRIPTION
Updated kubectl to 1.3.4

This addresses validation errors when using deployments or anything with apiVersion: extensions/v1beta1.
