### PR TITLE
Fix Javascript error when version is not set

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -7,6 +7,6 @@ exec 1>&2 # redirect all output to stderr for logging
 
 PATH=/usr/local/bin:$PATH
 
-echo '[]' >&3
+echo '{"version": {}}' >&3
 
 exit 0

--- a/assets/in
+++ b/assets/in
@@ -16,6 +16,6 @@ fi
 
 mkdir -p $destination_dir
 
-echo '{}' >&3
+echo '{"version": {}}' >&3
 
 exit 0


### PR DESCRIPTION
Concourse 3.14.1 UI breaks if step has version object not set

```
failed to fetch plan: BadPayload "Expecting an object at _.inputs[2].version but instead got: null"
```